### PR TITLE
Update to latest metrics_index list on main

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -171,15 +171,15 @@ libraries:
     url: https://github.com/mozilla/gecko-dev
     metrics_files:
       - browser/base/content/metrics.yaml
-      - gfx/metrics.yaml
-      - toolkit/components/glean/metrics.yaml
-      - toolkit/components/processtools/metrics.yaml
       - dom/media/metrics.yaml
       - dom/metrics.yaml
+      - gfx/metrics.yaml
       - netwerk/metrics.yaml
       - netwerk/protocol/http/metrics.yaml
+      - toolkit/components/glean/metrics.yaml
+      - toolkit/components/processtools/metrics.yaml
     ping_files:
-      - toolkit/components/glean/pings.yaml
+      - toolkit/components/telemetry/pings.yaml
     tag_files:
       - toolkit/components/glean/tags.yaml
     variants:
@@ -195,18 +195,15 @@ applications:
     notification_emails:
       - chutten@mozilla.com
     metrics_files: # When adding here, consider if you should also add to pine.
-      - browser/components/metrics.yaml
-      - browser/components/newtab/metrics.yaml
-      - browser/components/search/metrics.yaml
-      - browser/modules/metrics.yaml
-      - toolkit/components/extensions/metrics.yaml
-      - toolkit/components/search/metrics.yaml
-      - toolkit/components/telemetry/metrics.yaml
-      - toolkit/xre/metrics.yaml
-      - toolkit/components/nimbus/metrics.yaml
-      - toolkit/components/pdfjs/metrics.yaml
+      - browser/base/content/metrics.yaml
+      - dom/media/metrics.yaml
+      - dom/metrics.yaml
+      - gfx/metrics.yaml
+      - netwerk/metrics.yaml
+      - netwerk/protocol/http/metrics.yaml
+      - toolkit/components/glean/metrics.yaml
+      - toolkit/components/processtools/metrics.yaml
     ping_files:
-      - browser/components/newtab/pings.yaml
       - toolkit/components/telemetry/pings.yaml
     tag_files:
       - toolkit/components/glean/tags.yaml
@@ -230,9 +227,16 @@ applications:
     notification_emails:
       - chutten@mozilla.com
     metrics_files:
-      - toolkit/mozapps/update/metrics.yaml
+      - browser/base/content/metrics.yaml
+      - dom/media/metrics.yaml
+      - dom/metrics.yaml
+      - gfx/metrics.yaml
+      - netwerk/metrics.yaml
+      - netwerk/protocol/http/metrics.yaml
+      - toolkit/components/glean/metrics.yaml
+      - toolkit/components/processtools/metrics.yaml
     ping_files:
-      - toolkit/mozapps/update/pings.yaml
+      - toolkit/components/telemetry/pings.yaml
     tag_files:
       - toolkit/components/glean/tags.yaml
     dependencies:


### PR DESCRIPTION

This (automated) patch updates the list from metrics_index.py.

For reviewers:

* Canonical source for the index: <https://searchfox.org/mozilla-central/source/toolkit/components/glean/metrics_index.py>
* Please double-check that the changes here are valid and that the referenced files exist.
* Please double-check that none of the files are _deleted_ from the list.
* Delete this branch after merging or closing the PR.

---

The source code of this automation bot lives in [badboy/fog-update-bot](https://github.com/badboy/fog-update-bot).
